### PR TITLE
fixed TypeError being thrown due to lack of arguments

### DIFF
--- a/search.py
+++ b/search.py
@@ -27,5 +27,6 @@ def search(collection: str, query: str, populate: bool) -> list:
 
 
 if __name__ == "__main__":
-    query = sys.argv[1]
-    print(search(query))
+    src, query, populate = sys.argv[1:]
+    populate = bool(populate)
+    print(search(src, query, populate))

--- a/search.py
+++ b/search.py
@@ -29,4 +29,4 @@ def search(collection: str, query: str, populate: bool) -> list:
 if __name__ == "__main__":
     src, query, populate = sys.argv[1:]
     populate = bool(populate)
-    print(search(src, query, populate))
+    print(json.dumps(search(src, query, populate), ensure_ascii=False, indent=4))


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Contents

* changed the number of arguments to be taken in search.py to 3

## Reasons

* search function requires three arguments, but did not have only one passed

```
cd cities-api
python ./search.py "sao paulo"
```

```
Traceback (most recent call last):
  File "./search.py", line 31, in <module>
    print(search(query))
TypeError: search() missing 2 required positional arguments: 'query' and 'populate'
```