### PR TITLE
made it easier to understand how to use search.py

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
+import os
+import pathlib
 import re
 import sys
 import unicodedata
@@ -63,6 +65,13 @@ def populate_collection(model_list: List[Union[City, Country]], collection: str)
         for index, element in enumerate(model_list):
             model_list[index].update(populate_country(element))
     return model_list
+
+
+def get_collection_list() -> list:
+    src_list = os.listdir(SOURCE)
+    collection_list = [pathlib.Path(path).stem for path in src_list]
+    return collection_list
+
 
 ###########################################
 ##              Decorators               ##

--- a/search.py
+++ b/search.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import json
+import argparse
 import re
 import sys
 import unicodedata
 from typing import List
 
 from helpers import (load_file, model_selector, populate_collection,
-                     remove_accents, timeit)
+                     remove_accents, get_collection_list, timeit)
 from models import Model
 
 
@@ -26,7 +27,18 @@ def search(collection: str, query: str, populate: bool) -> list:
     return res
 
 
+def main():
+    collection_list = get_collection_list()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("collection", choices=collection_list)
+    parser.add_argument("query")
+    parser.add_argument("-p", "--populate", action="store_true")
+
+    args = parser.parse_args()
+
+    return search(args.collection, args.query, args.populate)
+
+
 if __name__ == "__main__":
-    src, query, populate = sys.argv[1:]
-    populate = bool(populate)
-    print(json.dumps(search(src, query, populate), ensure_ascii=False, indent=4))
+    print(json.dumps(main(), ensure_ascii=False, indent=4))


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Contents

* added a function to get a list of collections in src directory
* changed to more comprehensible argument parsing

## Usage

```
cd cities-api
python search.py cities "sao paulo" -p
```

This will result in a function call like this:

```
search("cities", "sao paulo", True)
```

`-p` and `--populate` have the same effect
If you do not grant these, this will result in a function call like this:

```
search("cities", "sao paulo", False)
```

If you want to see how to use it, please grant the `-h` or `--help` option

`python search.py -h`

```
usage: search.py [-h] [-p] {cities,continents,countries,languages} query

positional arguments:
  {cities,continents,countries,languages}
  query

optional arguments:
  -h, --help            show this help message and exit
  -p, --populate
```